### PR TITLE
docs(backend): add a Docker Hub overview and publish it from the release

### DIFF
--- a/.docs/RECORDS.md
+++ b/.docs/RECORDS.md
@@ -52,6 +52,7 @@ Date is the date the status last changed.
 | Consolidate onto `@clerk/backend`, dropping the end of life `clerk-sdk-node` | BHUVNESH | DONE | 14-08-2026 |
 | Normalise line endings and gate CI on `fmt:check` | BHUVNESH | DONE | 14-08-2026 |
 | Deployment environment checklist in `.docs/DEPLOYMENT.md` | BHUVNESH | DONE | 14-08-2026 |
+| Docker Hub overview, OCI image labels and description sync | BHUVNESH | DONE | 18-08-2026 |
 | Cache or tokenise the admin role instead of calling Clerk per request | BHUVNESH | PLANNED | 14-08-2026 |
 | Move Prisma migrations out of the container start command | BHUVNESH | PLANNED | 13-08-2026 |
 | Data storage layer, database design | BHUVNESH | BLOCKED | 18-08-2026 |

--- a/.github/workflows/docker-backend.testing.yml
+++ b/.github/workflows/docker-backend.testing.yml
@@ -155,6 +155,20 @@ jobs:
           context: ./BACKEND
           push: true
           tags: ${{ steps.version.outputs.TAGS }}
+          # Standard OCI metadata, baked into the image itself rather than
+          # carried by the registry, so `docker inspect` on a pulled image can
+          # say what it is and which commit produced it.
+          #
+          # `github.repositoryUrl` is deliberately not used for the source
+          # label. It yields a git protocol URL, git://github.com/owner/repo.git,
+          # which is not a browsable address. server_url plus repository gives
+          # the https one that tooling expects.
+          labels: |
+            org.opencontainers.image.title=studzee-api
+            org.opencontainers.image.description=Express and TypeScript backend for the Studzee education platform
+            org.opencontainers.image.version=${{ steps.version.outputs.VERSION }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           # Reuses layers across runs, which matters because the image now
           # installs the dependency tree twice, once in full for the build and
           # once with --omit=dev for the layer that ships.
@@ -165,6 +179,63 @@ jobs:
         run: |
           echo "Docker image successfully built and pushed:"
           echo "${{ steps.version.outputs.TAGS }}" | tr ',' '\n' | sed 's/^/  - /'
+
+      # The Docker Hub page text is a property of the repository, not of the
+      # image, so it cannot be set by a label and needs the Hub REST API.
+      #
+      # Only on a release. A commit SHA build is not what the page should
+      # describe, and rewriting the description on every dispatch is noise.
+      #
+      # Categories are deliberately not set here. They are chosen once from a
+      # fixed list and then never change, so automating them would mean
+      # shipping an API call whose payload shape cannot be verified from here,
+      # in exchange for saving a single click. They are set in the repository
+      # settings on Docker Hub.
+      - name: Update the Docker Hub description
+        if: startsWith(github.ref, 'refs/tags/backend-v')
+        env:
+          # Passed as environment rather than interpolated into the command, so
+          # the values are never part of a process argument list.
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          # Docker Hub is moving off password login, but this endpoint still
+          # accepts a personal access token in the password field, which is
+          # what DOCKER_PASSWORD already holds for docker/login-action.
+          TOKEN=$(curl -sS -X POST https://hub.docker.com/v2/users/login/ \
+            -H "Content-Type: application/json" \
+            -d "$(jq -nc --arg u "$DOCKERHUB_USERNAME" --arg p "$DOCKERHUB_TOKEN" \
+                  '{username: $u, password: $p}')" \
+            | jq -r '.token // empty')
+
+          if [ -z "$TOKEN" ]; then
+            echo "Could not obtain a Docker Hub API token."
+            echo "The image is already pushed. Only the page text is affected."
+            exit 1
+          fi
+
+          # --arg reads the file as a literal string, so backticks, quotes and
+          # newlines in the markdown cannot break out into the JSON.
+          PAYLOAD=$(jq -nc \
+            --arg short "studzee-api: Express and TypeScript backend for the Studzee education platform." \
+            --rawfile full BACKEND/DOCKERHUB.md \
+            '{description: $short, full_description: $full}')
+
+          STATUS=$(curl -sS -o /tmp/hub-response.json -w '%{http_code}' \
+            -X PATCH "https://hub.docker.com/v2/repositories/${DOCKERHUB_USERNAME}/studzee-backend/" \
+            -H "Authorization: JWT ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+
+          if [ "$STATUS" != "200" ]; then
+            echo "Docker Hub returned HTTP ${STATUS}:"
+            cat /tmp/hub-response.json
+            exit 1
+          fi
+
+          echo "Docker Hub description updated from BACKEND/DOCKERHUB.md."
 
       # The container runs prisma migrate deploy before the app, so the deploy
       # target needs DATABASE_URL reachable at boot or it exits 1 with P1001.

--- a/BACKEND/DOCKERHUB.md
+++ b/BACKEND/DOCKERHUB.md
@@ -1,0 +1,127 @@
+# STUDZEE API
+
+`studzee-api` is the backend for Studzee, an educational content platform. It
+owns content and caching, Clerk authentication, Expo push notifications,
+transactional email, the Clerk webhook, and the audit logs.
+
+Express 4 on Node 22, written in TypeScript. Built from
+[MasterBhuvnesh/studzee](https://github.com/MasterBhuvnesh/studzee).
+
+## QUICK START
+
+```bash
+docker run -d --name studzee-api \
+  -p 4000:3000 \
+  -e NODE_ENV=production \
+  -e PORT=3000 \
+  -e MONGO_URI="mongodb://..." \
+  -e DATABASE_URL="postgresql://..." \
+  -e REDIS_URL="redis://..." \
+  -e CLERK_SECRET_KEY="sk_..." \
+  -e CLERK_PUBLISHABLE_KEY="pk_..." \
+  -e S3_REGION="..." \
+  -e S3_ACCESS_KEY_ID="..." \
+  -e S3_SECRET_ACCESS_KEY="..." \
+  -e S3_BUCKET_IMAGES="images" \
+  -e S3_BUCKET_PDFS="pdfs" \
+  -e S3_ENDPOINT="https://<ref>.storage.supabase.co/storage/v1/s3" \
+  -e S3_PUBLIC_URL="https://<ref>.supabase.co/storage/v1/object/public" \
+  -e SMTP_HOST="..." \
+  -e SMTP_USER="..." \
+  -e SMTP_PASSWORD="..." \
+  -e EMAIL_FROM="Studzee <no-reply@example.com>" \
+  <namespace>/studzee-backend:latest
+```
+
+## THE PORT IS 3000
+
+The image serves on **3000**, not 4000. It declares `EXPOSE 3000` and its
+healthcheck probes 3000, so `PORT` must be `3000` inside the container. Publish
+it wherever you like on the host, for example `-p 4000:3000`.
+
+Setting `PORT` to anything else produces a container that serves traffic
+correctly and reports `unhealthy` forever, because the healthcheck is still
+probing 3000.
+
+## TAGS
+
+| Tag            | What it is                                                                                                                      |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `latest`       | The most recent release. Moved only by a `backend-v*` git tag.                                                                  |
+| `4.0.0`        | A specific release. Immutable.                                                                                                  |
+| `<7 char sha>` | A manual build from a branch. Never tagged `latest`, because an unreleased branch should not become what a deploy target pulls. |
+
+Pin to a version tag in production. `latest` moves under you.
+
+## ENVIRONMENT
+
+Sixteen variables are required and the process exits at startup without any one
+of them. The Zod schema parses at import time and throws on the first problem,
+so a missing variable is a named boot failure rather than a runtime surprise.
+
+`CLERK_SECRET_KEY`, `CLERK_PUBLISHABLE_KEY`, `MONGO_URI`, `DATABASE_URL`,
+`REDIS_URL`, `S3_REGION`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`,
+`S3_BUCKET_IMAGES`, `S3_BUCKET_PDFS`, `S3_ENDPOINT`, `S3_PUBLIC_URL`,
+`SMTP_HOST`, `SMTP_USER`, `SMTP_PASSWORD`, `EMAIL_FROM`.
+
+Also set these, which have defaults that are wrong for a deployment:
+
+- **`NODE_ENV=production`**. Required. The default is `development`.
+- **`PORT=3000`**. See above.
+- `CLERK_WEBHOOK_SIGNING_SECRET` if Clerk webhooks are enabled. Without it
+  `POST /webhooks/clerk` answers 500, because the svix signature is that
+  endpoint's only authentication and an unset secret is treated as a hard
+  failure rather than a skipped check.
+
+Full reference, including the optional variables and their defaults, is in
+[`.docs/DEPLOYMENT.md`](https://github.com/MasterBhuvnesh/studzee/blob/main/.docs/DEPLOYMENT.md).
+
+Two notes on the S3 variables. `S3_ENDPOINT` is the S3 API host and
+`S3_PUBLIC_URL` is the public object host. On Supabase these are different
+hosts and neither can be derived from the other, which is why both exist.
+
+## HEALTH
+
+| Endpoint            | Purpose                                                   |
+| ------------------- | --------------------------------------------------------- |
+| `/health/liveness`  | Process is up. This is what the image healthcheck probes. |
+| `/health/readiness` | Round trips MongoDB, Postgres and Redis.                  |
+
+```bash
+curl http://localhost:4000/health/readiness
+# {"status":"ready","checks":{"db":"ok","postgres":"ok","redis":"ok"}}
+```
+
+Readiness issues a real query against each store rather than reading driver
+connection flags, so it cannot report healthy while a dependency is down. Any
+`"error"` names the store that is not answering.
+
+## BEHAVIOUR WORTH KNOWING
+
+- **It migrates on start.** The container runs `prisma migrate deploy` before
+  the application. `DATABASE_URL` therefore has to be reachable at boot or the
+  container exits 1 with `P1001` before any application code runs. It also
+  means every replica attempts the migration, so run migrations separately if
+  you scale beyond one instance.
+- **Mongoose connects lazily.** A wrong `MONGO_URI` does not fail the
+  connection, it fails the first query, so it surfaces as a 500 on a route
+  rather than an error at boot.
+- **Clerk decodes the publishable key** to find its API host. A malformed
+  `CLERK_PUBLISHABLE_KEY` throws at parse time and reaches the error handler as
+  a 500, which makes an unauthenticated request look like a server fault
+  instead of a 401.
+- **Runs as a non-root user** (`appuser`).
+- **Admin routes need a role set in Clerk.** Authorisation reads
+  `publicMetadata.role === 'admin'`, and no code path sets it. Until at least
+  one user has it, the entire `/admin` surface answers 403 to everyone.
+
+## API
+
+Routes are grouped under `/content`, `/pdfs`, `/notifications`, `/admin`,
+`/webhooks` and `/health`. Every endpoint is documented in
+[`API.md`](https://github.com/MasterBhuvnesh/studzee/blob/main/BACKEND/API.md),
+written against what the handlers actually return.
+
+## LICENCE
+
+See the [repository](https://github.com/MasterBhuvnesh/studzee).

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -58,6 +58,50 @@ Open items carried forward. Move each into a dated entry once it is done.
 
 ## 2026-08-18
 
+**Branch:** `docs/dockerhub-overview`
+
+### Give the published image a Docker Hub page
+
+`backend-v4.0.0` was released and the image carried no description, no
+categories and no OCI metadata, so the Hub page was blank and `docker inspect`
+on a pulled image said nothing about what it was.
+
+`BACKEND/DOCKERHUB.md` is a new file rather than a reuse of the readme. The
+readme is 1696 lines and almost all of it is local development, compose
+profiles, Mailpit, MinIO and Prisma Studio, none of which applies to somebody
+who has the image and not the repository. The new file is written for that
+reader instead: the run command, the port, the required variables, the health
+endpoints, and the behaviour that costs people time.
+
+Every claim in it was checked against the Dockerfile, the config schema and
+`src/index.ts` rather than written from memory. That caught one error before it
+shipped: the route group list was missing `/pdfs`.
+
+Two things were added to the release workflow.
+
+- OCI labels on the image, so title, version, revision and source travel with
+  it. `github.repositoryUrl` is deliberately not used for the source label
+  because it yields a `git://` URL rather than a browsable one.
+- A step that pushes the description to Docker Hub. The page text is a
+  property of the repository and not of the image, so it cannot be set by a
+  label and needs the Hub REST API. It runs only on a version tag, because a
+  commit SHA build is not what the page should describe.
+
+Categories are deliberately not automated. They are chosen once from a fixed
+list of sixteen and then never change, so automating them would mean shipping
+an API call whose payload shape cannot be verified from here in exchange for
+saving one click. They are set in the Docker Hub repository settings.
+
+The category slug list was fetched from `https://hub.docker.com/v2/categories/`
+rather than assumed. `application-frameworks` is not among the sixteen valid
+slugs, so a call using it would have failed.
+
+**Note for whoever deploys next.** The `backend-v4.0.0` images were pushed
+under the previous Docker Hub credentials and are not in the current account.
+The workflow needs re-running on that tag to publish them where they belong.
+
+## 2026-08-18
+
 **Branch:** `feat/v2-architecture`
 
 ### Put the data storage design on hold


### PR DESCRIPTION
## SUMMARY

`backend-v4.0.0` shipped with a blank Docker Hub page and an image carrying no
metadata. This gives the published image a page, and keeps that page in sync
from the release pipeline.

## BACKEND/DOCKERHUB.md, new file

Written for someone who has the image and not the repository, which is why it
is not a reuse of the readme. `BACKEND/README.md` is 1696 lines and almost all
of it is local development: compose profiles, Mailpit, MinIO, Mongo Express,
Prisma Studio, seeding. None of that applies to a puller.

It covers the run command, the port, the sixteen required variables, the health
endpoints, the tag policy, and the behaviour that costs people time: migration
on start, lazy Mongoose connection, and the Clerk publishable key being decoded
at parse time.

Every claim was checked against the Dockerfile, the config schema and
`src/index.ts` rather than written from memory. That caught one error before it
shipped: the route group list was missing `/pdfs`.

`NODE_ENV=production` is stated as a requirement. The reason it matters, that
the `DEV_TOKEN` bypass grants admin when it is unset, stays in
`.docs/DEPLOYMENT.md` where operators need it, rather than on a public page
where it reads as a hint.

## WORKFLOW

**OCI labels on the image.** Title, version, revision and source now travel
with the image, so `docker inspect` on a pull can say what it is.
`github.repositoryUrl` is deliberately not used for the source label because it
yields `git://github.com/owner/repo.git`, which is not a browsable address.

**A description sync step.** The Hub page text is a property of the repository
and not of the image, so no label can set it and the REST API is required.

- Runs only on a `backend-v*` tag. A commit SHA build is not what the page
  should describe, and rewriting it on every dispatch is noise.
- Credentials pass as environment rather than being interpolated into the
  command, so they are never part of a process argument list.
- The markdown is embedded with `jq --rawfile`, so backticks, quotes and
  newlines in it cannot break out into the JSON.
- A non-200 response fails the step with the body printed, rather than passing
  silently and leaving the page stale.

## WHAT IS DELIBERATELY NOT AUTOMATED

Categories. They are chosen once from a fixed list of sixteen and then never
change, so automating them would mean shipping an API call whose payload shape
cannot be verified from here, in exchange for saving one click. They are set in
the Docker Hub repository settings.

The valid slugs were fetched from `https://hub.docker.com/v2/categories/`
rather than assumed. `application-frameworks` is not among them. The fitting
ones are `languages-and-frameworks`, `api-management` and `developer-tools`.

## VERIFICATION

The workflow YAML parses and the new step is present in the build job. The JSON
payload was built locally and checked: the short description is 79 characters
against a 100 limit, and the markdown round trips intact.

**Not verified, and it cannot be from here:** the Docker Hub API calls
themselves. The first release tag after this merges is the real test.
`/v2/users/login/` accepting a personal access token in the password field is
the load-bearing assumption. If it has changed, the step fails loudly after the
image has already pushed, so a release cannot be silently lost to it.

## ONE THING TO ACT ON SEPARATELY

The `backend-v4.0.0` images were pushed under the previous Docker Hub
credentials and are not in the current account. Neither candidate namespace
resolves publicly. The workflow needs re-running on that tag to publish them
where they belong, and that should happen before this sync step has a
repository to patch.