### PR TITLE
chore(backend): rename the published image to studzee-api

### DIFF
--- a/.docs/RECORDS.md
+++ b/.docs/RECORDS.md
@@ -53,6 +53,7 @@ Date is the date the status last changed.
 | Normalise line endings and gate CI on `fmt:check` | BHUVNESH | DONE | 14-08-2026 |
 | Deployment environment checklist in `.docs/DEPLOYMENT.md` | BHUVNESH | DONE | 14-08-2026 |
 | Docker Hub overview, OCI image labels and description sync | BHUVNESH | DONE | 18-08-2026 |
+| Rename the published image from `studzee-backend` to `studzee-api` | BHUVNESH | DONE | 18-08-2026 |
 | Cache or tokenise the admin role instead of calling Clerk per request | BHUVNESH | PLANNED | 14-08-2026 |
 | Move Prisma migrations out of the container start command | BHUVNESH | PLANNED | 13-08-2026 |
 | Data storage layer, database design | BHUVNESH | BLOCKED | 18-08-2026 |

--- a/.github/workflows/docker-backend.testing.yml
+++ b/.github/workflows/docker-backend.testing.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Work out the version and which tags to publish
         id: version
         run: |
-          NS="${{ secrets.DOCKER_USERNAME }}/studzee-backend"
+          NS="${{ secrets.DOCKER_USERNAME }}/studzee-api"
           if [[ $GITHUB_REF == refs/tags/backend-v* ]]; then
             # A version tag is a release, so it moves `latest`.
             VERSION="${GITHUB_REF#refs/tags/backend-v}"
@@ -224,7 +224,7 @@ jobs:
             '{description: $short, full_description: $full}')
 
           STATUS=$(curl -sS -o /tmp/hub-response.json -w '%{http_code}' \
-            -X PATCH "https://hub.docker.com/v2/repositories/${DOCKERHUB_USERNAME}/studzee-backend/" \
+            -X PATCH "https://hub.docker.com/v2/repositories/${DOCKERHUB_USERNAME}/studzee-api/" \
             -H "Authorization: JWT ${TOKEN}" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD")

--- a/BACKEND/DOCKERHUB.md
+++ b/BACKEND/DOCKERHUB.md
@@ -30,7 +30,7 @@ docker run -d --name studzee-api \
   -e SMTP_USER="..." \
   -e SMTP_PASSWORD="..." \
   -e EMAIL_FROM="Studzee <no-reply@example.com>" \
-  <namespace>/studzee-backend:latest
+  <namespace>/studzee-api:latest
 ```
 
 ## THE PORT IS 3000

--- a/BACKEND/README.md
+++ b/BACKEND/README.md
@@ -547,7 +547,7 @@ The `docker-compose.yml` defines **7 infrastructure services** plus the **API it
 
 #### 8. **The API (`api`)**
 
-- **Build**: the `production` target of the local `Dockerfile`, tagged `studzee-backend:local`
+- **Build**: the `production` target of the local `Dockerfile`, tagged `studzee-api:local`
 - **Purpose**: the service itself, for checking the image that actually ships
 - **Container Name**: `studzee_api`
 - **Profile**: `api`, so it is skipped unless you pass `--profile api`

--- a/BACKEND/docker-compose.yml
+++ b/BACKEND/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build:
       context: .
       target: production
-    image: studzee-backend:local
+    image: studzee-api:local
     container_name: studzee_api
     profiles: [api]
     restart: unless-stopped

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -58,6 +58,32 @@ Open items carried forward. Move each into a dated entry once it is done.
 
 ## 2026-08-18
 
+**Branch:** `chore/rename-image-to-studzee-api`
+
+### Rename the published image to studzee-api
+
+The image was published as `studzee-backend` while the package, the container
+and the OCI title were all already `studzee-api`. The owner asked for the
+published name to match.
+
+Changed in the workflow, in `DOCKERHUB.md`, in the compose local build tag and
+in the readme. `.docs/WORKFLOW-SAMPLE.md` is deliberately left alone. It is a
+snapshot of the workflow as it stood before the rewrite, so editing it would
+falsify the record it exists to keep.
+
+`BACKEND/postman.collection.json` keeps its `_postman_id`. That value is
+Postman's import deduplication key rather than a display name, so changing it
+would create a duplicate collection for anyone who has already imported it.
+
+**Docker Hub has no rename.** Pushing under the new name creates a second
+repository rather than moving the first, so this needs a release to populate
+`studzee-api`, and `studzee-backend` remains until it is deleted by hand. Its
+tags, its pull count and the description pushed to it on 4.0.1 all stay with
+the old name. Delete it only after a release has populated the new repository,
+so that there is never a window with no published image.
+
+## 2026-08-18
+
 **Branch:** `docs/dockerhub-overview`
 
 ### Give the published image a Docker Hub page


### PR DESCRIPTION
## SUMMARY

The image was published as `studzee-backend` while everything else already
called it `studzee-api`: the package name, the compose container, and the OCI
title label added in 4.0.1. The published name now matches.

## CHANGED

| Where | What |
| ----- | ---- |
| `docker-backend.testing.yml:128` | The tag namespace |
| `docker-backend.testing.yml:227` | The Docker Hub description PATCH URL |
| `BACKEND/DOCKERHUB.md` | The `docker run` example |
| `BACKEND/docker-compose.yml` | The local build tag, now `studzee-api:local` |
| `BACKEND/README.md` | The same local tag in the compose reference |

## DELIBERATELY NOT CHANGED

- **`.docs/WORKFLOW-SAMPLE.md`** is a snapshot of the workflow as it stood
  before the rewrite. Editing it would falsify the record it exists to keep.
- **`_postman_id`** in the Postman collection is Postman's import
  deduplication key, not a display name. Changing it would create a duplicate
  collection for anyone who has already imported it. The collection's display
  name is still "Studzee Backend API", which is a separate call to make if you
  want it aligned.

## THIS NEEDS A RELEASE, AND LEAVES THE OLD REPO BEHIND

**Docker Hub has no rename operation.** Pushing under the new name creates a
second repository rather than moving the first. So:

1. Merging this changes nothing on Docker Hub by itself. A `backend-v*` tag is
   what publishes to `studzee-api`.
2. `studzee-backend` keeps its tags, its pull count, and the description
   pushed to it during 4.0.1. It has to be deleted by hand.
3. Delete it only after a release has populated `studzee-api`, so there is
   never a window with no published image.

Anything already pulling `studzee-backend:latest` keeps working against a
frozen 4.0.1 until that repository is deleted, at which point it breaks. Worth
knowing if anything is wired to it.

## VERIFICATION

Both YAML files parse, `npm run fmt:check` passes, and the readme survived
editing with 116 box-drawing lines intact and no mojibake. No application code
is touched, so the image contents are unchanged.