### PR TITLE
docs: record the planned AWS deployment on ECS with Terraform

### DIFF
--- a/.docs/RECORDS.md
+++ b/.docs/RECORDS.md
@@ -85,6 +85,9 @@ Date is the date the status last changed.
 
 | FEATURE | DEVELOPER | STATUS | DATE |
 | ------- | --------- | ------ | ---- |
+| Terraform infrastructure as code for AWS | BHUVNESH | PLANNED | 18-08-2026 |
+| Deploy the backend on ECS with the image in ECR | BHUVNESH | PLANNED | 18-08-2026 |
+| Load balancing, autoscaling and Route 53 for the backend | BHUVNESH | PLANNED | 18-08-2026 |
 | Point the ingress `/noti` prefix at the merged backend | BHUVNESH | PLANNED | 10-08-2026 |
 | Set the renamed and new environment variables in the deployed environment | BHUVNESH | PLANNED | 11-08-2026 |
 | V2 architecture, overall | BHUVNESH | IN PROGRESS | 10-08-2026 |

--- a/.docs/TCSK.md
+++ b/.docs/TCSK.md
@@ -143,19 +143,55 @@ These are facts about the service today, not decisions about the design.
   A load balancer rule can carry it, which would close that item as part of
   this work rather than separately.
 
-### OPEN QUESTIONS, NOT YET DECIDED
+### DECIDED, 18-08-2026
 
-- **Where the data lives.** Content is on MongoDB and the notification data is
-  on Postgres, with object storage on Supabase. Whether those stay as managed
-  services outside AWS or move to RDS, DocumentDB and S3 is not decided, and
-  it interacts with the data storage design that is deliberately on hold.
-- **Whether ECR replaces Docker Hub or joins it.** The release workflow
-  publishes to Docker Hub today. ECS can pull from Docker Hub with credentials,
-  so ECR is a choice rather than a requirement.
+- **The data stores move into AWS.** Postgres becomes RDS, MongoDB becomes
+  DocumentDB, and object storage becomes S3. This is an engine and hosting
+  decision. It does not unblock the data storage design, which is a schema
+  question and stays on hold.
+- **Fargate**, not EC2 backed capacity.
+- **The image publishes to both ECR and Docker Hub**, from a separate workflow
+  file rather than by extending
+  `.github/workflows/docker-backend.testing.yml`.
+
+**No code for any of this yet.** The owner was explicit on 18-08-2026 that this
+is recorded as direction and is not to be started.
+
+### THINGS TO CHECK BEFORE BUILDING ANY OF IT
+
+Not objections. Each is cheap to check now and expensive to discover half way
+through a migration.
+
+- **DocumentDB is not MongoDB.** It emulates a wire protocol version rather
+  than being the same engine, and the gaps are real: some aggregation stages,
+  some `$lookup` forms, change streams and transaction support all vary by
+  version. The service uses Mongoose throughout, which mostly works, but the
+  aggregation and index usage in the content models should be checked against
+  the target DocumentDB version before committing to it. A migration that looks
+  compatible and then fails on one aggregation stage in production is the bad
+  outcome here.
+- **The S3 move is nearly free, and that is not an accident.** Storage already
+  speaks the S3 protocol through the AWS SDK, because Supabase was adopted over
+  that protocol on 11-08-2026. Moving to real S3 is mostly endpoint and
+  credential configuration. `forcePathStyle`, currently required for Supabase,
+  is not wanted against real S3, and `S3_PUBLIC_URL` stops needing to be a
+  separate host from `S3_ENDPOINT`.
+- **The buckets are public today** and the application stores a plain public
+  URL on the document which the clients fetch directly. On S3 that means either
+  deliberately relaxing block public access or putting CloudFront in front. It
+  has to be decided rather than inherited, because S3 blocks it by default and
+  Supabase did not.
+- **Two publish workflows means two copies of the tag logic.** The version and
+  tag derivation is the part worth sharing or keeping deliberately identical,
+  since drift between them would publish different tags to the two registries.
+  The Docker Hub description step has no ECR equivalent and should not be
+  duplicated.
+
+### STILL OPEN
+
 - **How the pipeline authenticates to AWS.** GitHub Actions supports OIDC role
   assumption, which avoids storing long lived access keys as repository
   secrets. Worth preferring over an access key pair.
-- **Fargate or EC2 backed capacity.**
 - **TLS.** Route 53 plus an ACM certificate terminating at the load balancer is
   the usual shape, but nothing is chosen.
 

--- a/.docs/TCSK.md
+++ b/.docs/TCSK.md
@@ -103,6 +103,62 @@ Stated by the user on 10-08-2026. This is the agreed direction. Follow it in ord
 - Buckets are public. The application stores a plain public URL on the document and the clients fetch it directly. Signed URLs were considered and rejected.
 - MinIO stays for local development. It is not replaced by pointing local work at Supabase.
 
+## PLANNED INFRASTRUCTURE, TERRAFORM ON AWS
+
+Stated by the owner on 18-08-2026. Direction only, nothing is designed or
+built yet, and no timeline is set. Recorded so the constraints that already
+exist are not rediscovered when the work starts.
+
+The intent is infrastructure as code with Terraform, deploying the backend to
+AWS on ECS with the image in ECR, behind a load balancer, with autoscaling and
+Route 53 in front.
+
+### WHAT THE BACKEND ALREADY IMPLIES FOR THIS
+
+These are facts about the service today, not decisions about the design.
+
+- **The container listens on 3000.** The image declares `EXPOSE 3000` and its
+  healthcheck probes 3000. The target group port is 3000 whatever the listener
+  does in front of it.
+- **`/health/liveness` is the health check to point a target group at.**
+  `/health/readiness` round trips MongoDB, Postgres and Redis on every call,
+  which is right for a deployment gate and wrong for something polled every
+  few seconds across every task.
+- **Migrations on container start block autoscaling.** The image runs
+  `prisma migrate deploy` before the application. With more than one task,
+  every task attempts the migration on every deploy and on every scale out.
+  This is already logged as deferred work, and it stops being deferrable the
+  moment a service runs more than one task. It wants to become a one off task
+  run before the service updates.
+- **Sixteen required variables, several of them secrets.** `CLERK_SECRET_KEY`,
+  `SMTP_PASSWORD` and `S3_SECRET_ACCESS_KEY` are credentials and belong in
+  Secrets Manager or SSM Parameter Store referenced by the task definition,
+  not in plain task definition environment entries where anyone with console
+  read can see them.
+- **`NODE_ENV` must be `production` and `DEV_TOKEN` must not exist in the task
+  definition at all.** The bypass grants admin whenever `NODE_ENV` is
+  `development` and `DEV_TOKEN` is set. See [`DEPLOYMENT.md`](DEPLOYMENT.md).
+- **The ingress repoint could be a listener rule.** The outstanding item, that
+  MOBILE 1.1.4 devices still call `POST /noti/api/register`, is a path rewrite.
+  A load balancer rule can carry it, which would close that item as part of
+  this work rather than separately.
+
+### OPEN QUESTIONS, NOT YET DECIDED
+
+- **Where the data lives.** Content is on MongoDB and the notification data is
+  on Postgres, with object storage on Supabase. Whether those stay as managed
+  services outside AWS or move to RDS, DocumentDB and S3 is not decided, and
+  it interacts with the data storage design that is deliberately on hold.
+- **Whether ECR replaces Docker Hub or joins it.** The release workflow
+  publishes to Docker Hub today. ECS can pull from Docker Hub with credentials,
+  so ECR is a choice rather than a requirement.
+- **How the pipeline authenticates to AWS.** GitHub Actions supports OIDC role
+  assumption, which avoids storing long lived access keys as repository
+  secrets. Worth preferring over an access key pair.
+- **Fargate or EC2 backed capacity.**
+- **TLS.** Route 53 plus an ACM certificate terminating at the load balancer is
+  the usual shape, but nothing is chosen.
+
 ## NOTES
 
 - The current working branch is `feat/v2-architecture`. The entire codebase is being rewritten.

--- a/.docs/TCSK.md
+++ b/.docs/TCSK.md
@@ -145,11 +145,24 @@ These are facts about the service today, not decisions about the design.
 
 ### DECIDED, 18-08-2026
 
-- **The data stores move into AWS.** Postgres becomes RDS, MongoDB becomes
-  DocumentDB, and object storage becomes S3. This is an engine and hosting
-  decision. It does not unblock the data storage design, which is a schema
-  question and stays on hold.
-- **Fargate**, not EC2 backed capacity.
+- **The managed stores are chosen per deployment target, not once.** Clarified
+  by the owner on 18-08-2026. **On the AWS path** Postgres is RDS, MongoDB is
+  DocumentDB and object storage is S3. **Anywhere else**, meaning any host that
+  simply pulls the Docker Hub image, the free tiers stay: MongoDB Atlas,
+  Supabase Postgres and Supabase Storage as they are used today. The AWS
+  choices are not a migration away from the free services, they are what that
+  one target uses.
+
+  **This makes portability a requirement rather than a nice property.** The
+  service has to keep running against both sets, so nothing may depend on an
+  AWS specific feature, and the code has to stay inside the intersection of
+  real MongoDB and DocumentDB rather than merely inside DocumentDB. Every store
+  is already reached through an environment variable and a standard driver, so
+  this holds today. It is a constraint on future work, not a change to make.
+
+  This is an engine and hosting decision either way. It does not unblock the
+  data storage design, which is a schema question and stays on hold.
+- **Fargate**, not EC2 backed capacity, on the AWS path.
 - **The image publishes to both ECR and Docker Hub**, from a separate workflow
   file rather than by extending
   `.github/workflows/docker-backend.testing.yml`.
@@ -162,14 +175,19 @@ is recorded as direction and is not to be started.
 Not objections. Each is cheap to check now and expensive to discover half way
 through a migration.
 
-- **DocumentDB is not MongoDB.** It emulates a wire protocol version rather
-  than being the same engine, and the gaps are real: some aggregation stages,
-  some `$lookup` forms, change streams and transaction support all vary by
-  version. The service uses Mongoose throughout, which mostly works, but the
-  aggregation and index usage in the content models should be checked against
-  the target DocumentDB version before committing to it. A migration that looks
-  compatible and then fails on one aggregation stage in production is the bad
-  outcome here.
+- **DocumentDB is not MongoDB, and this now binds all deployments.** It
+  emulates a wire protocol version rather than being the same engine, and the
+  gaps are real: some aggregation stages, some `$lookup` forms, change streams
+  and transaction support all vary by version.
+
+  Because Atlas stays in use on the non AWS path, the code cannot simply be
+  ported to DocumentDB. It has to stay inside **the intersection** of the two
+  for as long as both are targets. The practical effect is that DocumentDB
+  becomes the limiting factor on what may be written against MongoDB anywhere,
+  including features added later that have nothing to do with AWS. The content
+  models should be checked against the target DocumentDB version before this is
+  committed to, because a query that looks compatible and then fails on one
+  aggregation stage in production is the bad outcome here.
 - **The S3 move is nearly free, and that is not an accident.** Storage already
   speaks the S3 protocol through the AWS SDK, because Supabase was adopted over
   that protocol on 11-08-2026. Moving to real S3 is mostly endpoint and

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -88,11 +88,25 @@ One thing worth connecting: the outstanding ingress repoint, where MOBILE
 load balancer listener rule can carry. That item can close as part of this
 work rather than separately.
 
-The owner settled three of the open questions the same day. The data stores
-move into AWS, so Postgres becomes RDS, MongoDB becomes DocumentDB and object
-storage becomes S3. Capacity is Fargate. The image publishes to both ECR and
-Docker Hub, from a separate workflow file rather than by extending the
-existing one.
+The owner settled three of the open questions the same day. Capacity is
+Fargate. The image publishes to both ECR and Docker Hub, from a separate
+workflow file rather than by extending the existing one. And the managed
+stores are chosen per deployment target rather than once: on the AWS path
+Postgres is RDS, MongoDB is DocumentDB and object storage is S3, while any
+host that simply pulls the Docker Hub image keeps the free tiers in use today,
+MongoDB Atlas and Supabase.
+
+That last point was first written here as a wholesale migration into AWS,
+which was wrong, and the owner corrected it the same day. The AWS services are
+what one target uses, not a replacement for the free ones.
+
+The correction matters more than a wording fix, because it makes portability a
+requirement rather than a property that happens to hold. The service has to
+keep running against both sets, so the code has to stay inside the
+intersection of real MongoDB and DocumentDB rather than merely inside
+DocumentDB, and DocumentDB becomes the limiting factor on what may be written
+against MongoDB anywhere. Every store is already reached through an
+environment variable and a standard driver, so nothing needs changing today.
 
 Moving the engines does not unblock the data storage design. That is a schema
 question and it stays on hold.
@@ -100,7 +114,9 @@ question and it stays on hold.
 Three things are recorded to check before any of it is built. DocumentDB
 emulates a MongoDB wire protocol version rather than being the same engine, so
 the aggregation and index usage needs checking against the target version
-first. The S3 move is nearly free because storage already speaks the S3
+first, and with Atlas staying in use elsewhere that check binds every
+deployment and not only the AWS one. The S3 move is nearly free because
+storage already speaks the S3
 protocol, a side effect of adopting Supabase over that protocol on 11-08-2026,
 though `forcePathStyle` is not wanted against real S3. The buckets are public
 today, which on S3 has to be chosen deliberately rather than inherited.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -88,12 +88,28 @@ One thing worth connecting: the outstanding ingress repoint, where MOBILE
 load balancer listener rule can carry. That item can close as part of this
 work rather than separately.
 
-Open questions are recorded rather than answered: whether the databases and
-object storage stay as managed services outside AWS or move to RDS,
-DocumentDB and S3, whether ECR replaces Docker Hub or joins it, how the
-pipeline authenticates to AWS, and Fargate against EC2 backed capacity. The
-first of those interacts with the data storage design that is on hold, so it
-cannot be settled before that is.
+The owner settled three of the open questions the same day. The data stores
+move into AWS, so Postgres becomes RDS, MongoDB becomes DocumentDB and object
+storage becomes S3. Capacity is Fargate. The image publishes to both ECR and
+Docker Hub, from a separate workflow file rather than by extending the
+existing one.
+
+Moving the engines does not unblock the data storage design. That is a schema
+question and it stays on hold.
+
+Three things are recorded to check before any of it is built. DocumentDB
+emulates a MongoDB wire protocol version rather than being the same engine, so
+the aggregation and index usage needs checking against the target version
+first. The S3 move is nearly free because storage already speaks the S3
+protocol, a side effect of adopting Supabase over that protocol on 11-08-2026,
+though `forcePathStyle` is not wanted against real S3. The buckets are public
+today, which on S3 has to be chosen deliberately rather than inherited.
+
+Still open: how the pipeline authenticates to AWS, where OIDC role assumption
+avoids long lived keys in repository secrets, and the TLS shape.
+
+**No code for any of this.** The owner was explicit that this is direction to
+record, not work to start.
 
 ## 2026-08-18
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -58,6 +58,45 @@ Open items carried forward. Move each into a dated entry once it is done.
 
 ## 2026-08-18
 
+**Branch:** `docs/record-aws-terraform-plan`
+
+### Record the planned AWS and Terraform deployment
+
+The owner stated the intended deployment direction: infrastructure as code
+with Terraform, the backend on ECS with the image in ECR, behind a load
+balancer, with autoscaling and Route 53. Direction only. Nothing is designed
+or built, and no timeline is set.
+
+Recorded in [`.docs/TCSK.md`](.docs/TCSK.md) under planned infrastructure,
+with the constraints the service already imposes so they are not rediscovered
+later. The ones that will shape the design most:
+
+- The container listens on 3000, so that is the target group port.
+- `/health/liveness` is the health check to poll. `/health/readiness` round
+  trips three stores and is a deployment gate, not something to hit every few
+  seconds from every task.
+- Migrations run at container start, so every task attempts them on every
+  deploy and every scale out. Already logged as deferred work, this stops
+  being deferrable the moment the service runs more than one task.
+- Several of the sixteen required variables are credentials and belong in
+  Secrets Manager or Parameter Store rather than plain task definition
+  environment entries.
+- `DEV_TOKEN` must not exist in the task definition at all.
+
+One thing worth connecting: the outstanding ingress repoint, where MOBILE
+1.1.4 devices still call `POST /noti/api/register`, is a path rewrite that a
+load balancer listener rule can carry. That item can close as part of this
+work rather than separately.
+
+Open questions are recorded rather than answered: whether the databases and
+object storage stay as managed services outside AWS or move to RDS,
+DocumentDB and S3, whether ECR replaces Docker Hub or joins it, how the
+pipeline authenticates to AWS, and Fargate against EC2 backed capacity. The
+first of those interacts with the data storage design that is on hold, so it
+cannot be settled before that is.
+
+## 2026-08-18
+
 **Branch:** `chore/rename-image-to-studzee-api`
 
 ### Rename the published image to studzee-api


### PR DESCRIPTION
Records the deployment direction stated on 18-08-2026. Docs only, no code. The owner was explicit that this is direction to record, not work to start.

## THE PLAN

Terraform for infrastructure as code, the backend on ECS Fargate with the image in ECR, behind a load balancer, with autoscaling and Route 53.

## STORES ARE CHOSEN PER TARGET, NOT ONCE

- **On the AWS path**: Postgres is RDS, MongoDB is DocumentDB, object storage is S3.
- **Anywhere else** (any host pulling the Docker Hub image): the free tiers stay, MongoDB Atlas and Supabase, as used today.

The AWS services are what that one target uses, not a migration away from the free ones. An earlier commit on this branch recorded it as a wholesale migration; that was wrong and is corrected here.

**This makes portability a requirement rather than a property that happens to hold.** The service must keep running against both sets, so nothing may depend on an AWS specific feature. Every store is already reached through an environment variable and a standard driver, so the constraint holds today with no code change.

## CONSTRAINTS THE SERVICE ALREADY IMPOSES

Facts about the backend today, not decisions about the design.

- **Port 3000.** The container listens and healthchecks there, so that is the target group port.
- **Poll /health/liveness, not /health/readiness.** Readiness round trips MongoDB, Postgres and Redis on every call. Right for a deployment gate, wrong for every task polled every few seconds.
- **Migrations at container start block autoscaling.** The image runs prisma migrate deploy before the app, so every task attempts it on every deploy and every scale out. Already logged as deferred work, it stops being deferrable the moment more than one task runs.
- **Credentials belong in Secrets Manager or Parameter Store.** Three of the sixteen required variables are secrets.
- **DEV_TOKEN must not exist in the task definition.** The bypass it enables grants admin.

## THINGS TO CHECK BEFORE BUILDING

- **DocumentDB is not MongoDB**, and because Atlas stays in use elsewhere, the code must stay inside the *intersection* of the two rather than merely inside DocumentDB. DocumentDB becomes the limiting factor on what may be written against MongoDB anywhere, including in features unrelated to AWS. This is no longer a check that waits for the AWS work.
- **The S3 move is nearly free**, because storage already speaks the S3 protocol through the AWS SDK, a side effect of adopting Supabase over that protocol on 11-08-2026. forcePathStyle is not wanted against real S3.
- **The buckets are public today** and the app stores plain public URLs clients fetch directly. S3 blocks public access by default where Supabase did not, so that becomes a deliberate choice.
- **Two publish workflows means two copies of the tag derivation.** Drift would publish different tags to each registry. The Docker Hub description step has no ECR equivalent and should not be duplicated.

## ONE CONNECTION WORTH MAKING

The outstanding ingress repoint, where MOBILE 1.1.4 devices still call POST /noti/api/register, is a path rewrite. A load balancer listener rule can carry it, closing that item as part of this work rather than separately.

## STILL OPEN

How the pipeline authenticates to AWS (OIDC role assumption avoids long lived keys in repository secrets), and the TLS shape.